### PR TITLE
Nicer Output

### DIFF
--- a/src/Model.hs
+++ b/src/Model.hs
@@ -122,7 +122,7 @@ post' account amount = HL.nullposting { HL.paccount = account
                                       }
 
 addPosting :: HL.Posting -> HL.Transaction -> HL.Transaction
-addPosting p t = t { HL.tpostings = p : HL.tpostings t }
+addPosting p t = t { HL.tpostings = (HL.tpostings t) ++ [p] }
 
 trySumAmount :: HL.JournalContext -> Text -> Maybe HL.MixedAmount
 trySumAmount ctx = either (const Nothing) Just . parseAmount ctx

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -241,7 +241,7 @@ setEdit content edit = edit & editContentsL .~ zipper
   where zipper = gotoEOL (stringZipper [T.unpack content] (Just 1))
 
 addToJournal :: HL.Transaction -> FilePath -> IO ()
-addToJournal trans path = appendFile path (show trans)
+addToJournal trans path = appendFile path (HL.showTransaction trans)
 
 
 ledgerPath :: FilePath -> FilePath


### PR DESCRIPTION
This PR does two things (if you like one but not the other I can revert one):

- Order postings in the generated transaction in the same order that they are entered. IMO this makes more sense because I can enter postings in the same order I enter them manually. For example I typically like to put expense categories before the asset used to pay for the expense.
- Omits unnecessary amounts, just like shown in the UI by using the same function to output to the file as is displayed in the UI.

@hpdeifel 