### PR TITLE
Add a default currency option

### DIFF
--- a/src/AmountParser.hs
+++ b/src/AmountParser.hs
@@ -7,6 +7,16 @@ import           Text.Parsec
 
 type Parser = Parsec String HL.JournalContext
 
+isJustANumber :: String -> Bool
+isJustANumber s = case reads s :: [(Double, String)] of
+  [(_, "")] -> True
+  _         -> False
+
+parseAmountWithDefault :: HL.JournalContext -> Text -> Either String HL.MixedAmount
+parseAmountWithDefault context t =
+  let s = T.unpack t in
+  if isJustANumber s then parseAmount context (T.pack ('$' : s)) else parseAmount context t
+
 parseAmount :: HL.JournalContext -> Text -> Either String HL.MixedAmount
 parseAmount context t = case runParser (mixed <* optional spaces <* eof) context "" (T.unpack t) of
   Left err -> Left (show err)

--- a/src/AmountParser.hs
+++ b/src/AmountParser.hs
@@ -8,14 +8,14 @@ import           Text.Parsec
 type Parser = Parsec String HL.JournalContext
 
 isJustANumber :: String -> Bool
-isJustANumber s = case reads s :: [(Double, String)] of
+isJustANumber s = case reads s :: [(HL.Quantity, String)] of
   [(_, "")] -> True
   _         -> False
 
-parseAmountWithDefault :: HL.JournalContext -> Text -> Either String HL.MixedAmount
-parseAmountWithDefault context t =
+parseAmountWithDefault :: HL.JournalContext -> String -> Text -> Either String HL.MixedAmount
+parseAmountWithDefault context defaultCurrency t =
   let s = T.unpack t in
-  if isJustANumber s then parseAmount context (T.pack ('$' : s)) else parseAmount context t
+  if isJustANumber s then parseAmount context (T.pack (defaultCurrency ++ s)) else parseAmount context t
 
 parseAmount :: HL.JournalContext -> Text -> Either String HL.MixedAmount
 parseAmount context t = case runParser (mixed <* optional spaces <* eof) context "" (T.unpack t) of

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -35,8 +35,8 @@ data MaybeStep = Finished HL.Transaction
                | Step Step
                deriving (Eq, Show)
 
-nextStep :: HL.Journal -> DateFormat -> Either Text Text -> Step -> IO (Either Text MaybeStep)
-nextStep journal dateFormat entryText current = case current of
+nextStep :: HL.Journal -> DateFormat -> String -> Either Text Text -> Step -> IO (Either Text MaybeStep)
+nextStep journal dateFormat defaultCurrency entryText current = case current of
   DateQuestion ->
     fmap (Step . DescriptionQuestion) <$> either (parseDateWithToday dateFormat)
                                                  parseHLDateWithToday
@@ -51,7 +51,7 @@ nextStep journal dateFormat entryText current = case current of
       -> return $ Left $ "Transaction not balanced! Please balance your transaction before adding it to the journal."
     | otherwise        -> return $ Right $ Step $
       AmountQuestion (T.unpack (fromEither entryText)) trans
-  AmountQuestion name trans -> case parseAmountWithDefault (HL.jContext journal) (fromEither entryText) of
+  AmountQuestion name trans -> case parseAmountWithDefault (HL.jContext journal) defaultCurrency (fromEither entryText) of
     Left err -> return $ Left (T.pack err)
     Right amount -> return $ Right $ Step $
       let newPosting = post' name amount
@@ -74,19 +74,19 @@ undo current = case current of
   AmountQuestion _ trans -> Right $ AccountQuestion trans
   FinalQuestion trans -> undo (AccountQuestion trans)
 
-context :: HL.Journal -> DateFormat -> Text -> Step -> IO [Text]
-context _ dateFormat entryText DateQuestion = parseDateWithToday dateFormat entryText >>= \case
+context :: HL.Journal -> DateFormat -> String -> Text -> Step -> IO [Text]
+context _ dateFormat _ entryText DateQuestion = parseDateWithToday dateFormat entryText >>= \case
   Left _ -> return []
   Right date -> return [T.pack $ HL.showDate date]
-context j _ entryText (DescriptionQuestion _) = return $
+context j _ _ entryText (DescriptionQuestion _) = return $
   let descs = map T.pack $ HL.journalDescriptions j
   in sortBy (descUses j) $ filter (entryText `matches`) descs
-context j _ entryText (AccountQuestion _) = return $
+context j _ _ entryText (AccountQuestion _) = return $
   let names = map T.pack $ HL.journalAccountNames j
   in  filter (entryText `matches`) names
-context journal _ entryText (AmountQuestion _ _) = return $
-  maybeToList $ T.pack . HL.showMixedAmount <$> trySumAmount (HL.jContext journal) entryText
-context _ _ _  (FinalQuestion _) = return []
+context journal _ defaultCurrency entryText (AmountQuestion _ _) = return $
+  maybeToList $ T.pack . HL.showMixedAmount <$> trySumAmount (HL.jContext journal) defaultCurrency entryText
+context _ _ _ _  (FinalQuestion _) = return []
 
 -- | Suggest the initial text of the entry box for each step
 --
@@ -124,8 +124,8 @@ post' account amount = HL.nullposting { HL.paccount = account
 addPosting :: HL.Posting -> HL.Transaction -> HL.Transaction
 addPosting p t = t { HL.tpostings = (HL.tpostings t) ++ [p] }
 
-trySumAmount :: HL.JournalContext -> Text -> Maybe HL.MixedAmount
-trySumAmount ctx = either (const Nothing) Just . parseAmountWithDefault ctx
+trySumAmount :: HL.JournalContext -> String -> Text -> Maybe HL.MixedAmount
+trySumAmount ctx defaultCurrency = either (const Nothing) Just . parseAmountWithDefault ctx defaultCurrency
 
 
 -- | Given a previous similar transaction, suggest the next posting to enter

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -51,7 +51,7 @@ nextStep journal dateFormat entryText current = case current of
       -> return $ Left $ "Transaction not balanced! Please balance your transaction before adding it to the journal."
     | otherwise        -> return $ Right $ Step $
       AmountQuestion (T.unpack (fromEither entryText)) trans
-  AmountQuestion name trans -> case parseAmount (HL.jContext journal) (fromEither entryText) of
+  AmountQuestion name trans -> case parseAmountWithDefault (HL.jContext journal) (fromEither entryText) of
     Left err -> return $ Left (T.pack err)
     Right amount -> return $ Right $ Step $
       let newPosting = post' name amount
@@ -125,7 +125,7 @@ addPosting :: HL.Posting -> HL.Transaction -> HL.Transaction
 addPosting p t = t { HL.tpostings = (HL.tpostings t) ++ [p] }
 
 trySumAmount :: HL.JournalContext -> Text -> Maybe HL.MixedAmount
-trySumAmount ctx = either (const Nothing) Just . parseAmount ctx
+trySumAmount ctx = either (const Nothing) Just . parseAmountWithDefault ctx
 
 
 -- | Given a previous similar transaction, suggest the next posting to enter


### PR DESCRIPTION
Add a flag and config variable that contains a string that is prepended
to amounts when they are just bare decimal numbers with no other
currency. Useful for people that use only one currency most of the
time, which is probably most people.

I threaded it all the way through just like the date format, but I don't think that threading approach is nice or scalable, the diff for adding a config option like this shouldn't be as large as this PR is. See the first commit (which I'll squash if you want) for how easy it was without the config option.

@hpdeifel 