### PR TITLE
Allow to edit comments

### DIFF
--- a/hledger-iadd.cabal
+++ b/hledger-iadd.cabal
@@ -50,6 +50,7 @@ library
                      , ConfigParser
                      , Brick.Widgets.List.Utils
                      , Brick.Widgets.HelpMessage
+                     , Brick.Widgets.CommentDialog
                      , Brick.Widgets.BetterDialog
                      , Brick.Widgets.WrappedText
                      , Brick.Widgets.Edit.EmacsBindings

--- a/src/Brick/Widgets/CommentDialog.hs
+++ b/src/Brick/Widgets/CommentDialog.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Brick.Widgets.CommentDialog
+  ( CommentWidget
+  , commentWidget
+  , renderCommentWidget
+  , commentDialogComment
+  , CommentAction(..)
+  , handleCommentEvent
+  ) where
+
+import Brick
+import Brick.Widgets.Edit hiding (handleEditorEvent)
+import Brick.Widgets.Dialog
+import Brick.Widgets.Center
+import Data.Text.Zipper
+import Graphics.Vty.Input
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+import Brick.Widgets.Edit.EmacsBindings
+
+import Debug.Trace
+
+data CommentWidget n = CommentWidget
+  { origComment :: Text
+  , textArea :: Editor Text n
+  , dialogWidget :: Dialog ()
+  }
+
+commentWidget :: n -> Text -> CommentWidget n
+commentWidget name comment =
+  let
+    title = "ESC: cancel, RET: accept, Alt-RET: New line"
+    maxWidth = 80
+    diag = dialog (Just title) Nothing maxWidth
+    edit = editorText name (txt . T.unlines) Nothing comment
+  in
+    CommentWidget
+      { origComment = comment
+      , textArea = applyEdit gotoEnd edit
+      , dialogWidget = diag
+      }
+
+data CommentAction n = CommentContinue (CommentWidget n)
+                     | CommentFinished Text
+
+handleCommentEvent :: Event -> CommentWidget n -> EventM n (CommentAction n)
+handleCommentEvent ev widget = case ev of
+  EvKey KEsc [] -> return $ CommentFinished (origComment widget)
+  EvKey KEnter [] -> return $ CommentFinished (commentDialogComment widget)
+  EvKey KEnter [MMeta] -> return $ CommentContinue $
+    widget { textArea = applyEdit breakLine (textArea widget) }
+  _ -> do
+    textArea' <- handleEditorEvent ev (textArea widget)
+    return $ CommentContinue $ CommentWidget (origComment widget) textArea' (dialogWidget widget)
+
+renderCommentWidget :: (Ord n, Show n) => CommentWidget n -> Widget n
+renderCommentWidget widget =
+  let
+    height = min (length (getEditContents (textArea widget)) + 4) 24
+    textArea' =  padTop (Pad 1) $ txt "Comment: " <+> renderEditor True (textArea widget)
+  in
+    vCenterLayer $ vLimit height $ renderDialog (dialogWidget widget) textArea'
+
+commentDialogComment :: CommentWidget n -> Text
+commentDialogComment = T.intercalate "\n" . traceShowId . getEditContents . textArea
+
+gotoEnd :: Monoid a => TextZipper a -> TextZipper a
+gotoEnd zipper =
+  let
+    lengths = lineLengths zipper
+    (row, col) = (length lengths, last lengths)
+  in
+    moveCursor (row-1, col) zipper

--- a/src/Brick/Widgets/CommentDialog.hs
+++ b/src/Brick/Widgets/CommentDialog.hs
@@ -20,8 +20,6 @@ import           Data.Text (Text)
 
 import Brick.Widgets.Edit.EmacsBindings
 
-import Debug.Trace
-
 data CommentWidget n = CommentWidget
   { origComment :: Text
   , textArea :: Editor Text n
@@ -64,7 +62,7 @@ renderCommentWidget widget =
     vCenterLayer $ vLimit height $ renderDialog (dialogWidget widget) textArea'
 
 commentDialogComment :: CommentWidget n -> Text
-commentDialogComment = T.intercalate "\n" . traceShowId . getEditContents . textArea
+commentDialogComment = T.intercalate "\n" . getEditContents . textArea
 
 gotoEnd :: Monoid a => TextZipper a -> TextZipper a
 gotoEnd zipper =

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -11,6 +11,8 @@ module Model
        , suggest
        , setCurrentComment
        , getCurrentComment
+       , setTransactionComment
+       , getTransactionComment
 
        -- * Helpers exported for easier testing
        , accountsByFrequency
@@ -142,6 +144,24 @@ setCurrentComment comment step = case step of
   DescriptionQuestion date _ -> DescriptionQuestion date comment
   AccountQuestion trans _ -> AccountQuestion trans comment
   AmountQuestion trans name _ -> AmountQuestion trans name comment
+  FinalQuestion trans -> FinalQuestion trans { HL.tcomment = comment }
+
+getTransactionComment :: Step -> Comment
+getTransactionComment step = case step of
+  DateQuestion c -> c
+  DescriptionQuestion _ c -> c
+  AccountQuestion trans _ -> HL.tcomment trans
+  AmountQuestion _ trans _ -> HL.tcomment trans
+  FinalQuestion trans -> HL.tcomment trans
+
+setTransactionComment :: Comment -> Step -> Step
+setTransactionComment comment step = case step of
+  DateQuestion _ -> DateQuestion comment
+  DescriptionQuestion date _ -> DescriptionQuestion date comment
+  AccountQuestion trans comment' ->
+    AccountQuestion (trans { HL.tcomment = comment }) comment'
+  AmountQuestion name trans comment' ->
+    AmountQuestion name (trans { HL.tcomment = comment }) comment'
   FinalQuestion trans -> FinalQuestion trans { HL.tcomment = comment }
 
 -- | Returns true if the pattern is not empty and all of its words occur in the string

--- a/src/View.hs
+++ b/src/View.hs
@@ -1,6 +1,12 @@
 {-# LANGUAGE LambdaCase, OverloadedStrings #-}
 
-module View where
+module View
+  ( viewState
+  , viewQuestion
+  , viewContext
+  , viewSuggestion
+  , viewMessage
+  ) where
 
 import           Brick
 import           Brick.Widgets.List

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -147,6 +147,8 @@ event as (VtyEvent ev) = case asDialog as of
     EvKey (KChar '\t') [] -> continue (insertSelected as)
     EvKey (KChar ';') [] -> continue as { asStep = setCurrentComment "Test" (asStep as) }
     EvKey (KChar ';') [MMeta] -> continue as { asStep = setCurrentComment "" (asStep as) }
+    EvKey (KChar ':') [] -> continue as { asStep = setTransactionComment "Foobar" (asStep as) }
+    EvKey (KChar ':') [MMeta] -> continue as { asStep = setTransactionComment "" (asStep as) }
     EvKey KEsc [] -> case asStep as of
       DateQuestion _
         | T.null (editText as) -> halt as

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -130,12 +130,12 @@ event as (VtyEvent ev) = case asDialog as of
       | otherwise -> continue as { asDialog = NoDialog }
     _ -> continue as
   NoDialog -> case ev of
-    EvKey (KChar 'c') [MCtrl]
-      | asStep as == DateQuestion -> halt as
-      | otherwise -> continue as { asDialog = QuitDialog }
-    EvKey (KChar 'd') [MCtrl]
-      | asStep as == DateQuestion -> halt as
-      | otherwise -> continue as { asDialog = QuitDialog }
+    EvKey (KChar 'c') [MCtrl] -> case asStep as of
+      DateQuestion _ -> halt as
+      _              -> continue as { asDialog = QuitDialog }
+    EvKey (KChar 'd') [MCtrl] -> case asStep as of
+      DateQuestion _ -> halt as
+      _              -> continue as { asDialog = QuitDialog }
     EvKey (KChar 'n') [MCtrl] -> continue as { asContext = listMoveDown $ asContext as
                                              , asMessage = ""}
     EvKey KDown [] -> continue as { asContext = listMoveDown $ asContext as
@@ -145,10 +145,13 @@ event as (VtyEvent ev) = case asDialog as of
     EvKey KUp [] -> continue as { asContext = listMoveUp $ asContext as
                                , asMessage = ""}
     EvKey (KChar '\t') [] -> continue (insertSelected as)
-    EvKey KEsc []
-      | asStep as == DateQuestion && T.null (editText as) -> halt as
-      | asStep as == DateQuestion -> liftIO (reset as) >>= continue
-      | otherwise -> continue as { asDialog = AbortDialog }
+    EvKey (KChar ';') [] -> continue as { asStep = setCurrentComment "Test" (asStep as) }
+    EvKey (KChar ';') [MMeta] -> continue as { asStep = setCurrentComment "" (asStep as) }
+    EvKey KEsc [] -> case asStep as of
+      DateQuestion _
+        | T.null (editText as) -> halt as
+        | otherwise -> liftIO (reset as) >>= continue
+      _ -> continue as { asDialog = AbortDialog }
     EvKey (KChar 'z') [MCtrl] -> liftIO (doUndo as) >>= continue
     EvKey KEnter [MMeta] -> liftIO (doNextStep False as) >>= continue
     EvKey KEnter [] -> liftIO (doNextStep True as) >>= continue
@@ -169,9 +172,9 @@ event as _ = continue as
 
 reset :: AppState -> IO AppState
 reset as = do
-  sugg <- suggest (asJournal as) (asDateFormat as) DateQuestion
+  sugg <- suggest (asJournal as) (asDateFormat as) (DateQuestion "")
   return as
-    { asStep = DateQuestion
+    { asStep = DateQuestion ""
     , asEditor = clearEdit (asEditor as)
     , asContext = ctxList V.empty
     , asSuggestion = sugg
@@ -206,9 +209,9 @@ doNextStep useSelected as = do
     Left err -> return as { asMessage = err }
     Right (Finished trans) -> do
       liftIO $ addToJournal trans (asFilename as)
-      sugg <- suggest (asJournal as) (asDateFormat as) DateQuestion
+      sugg <- suggest (asJournal as) (asDateFormat as) (DateQuestion "")
       return AppState
-        { asStep = DateQuestion
+        { asStep = DateQuestion ""
         , asJournal = addTransactionEnd trans (asJournal  as)
         , asEditor = clearEdit (asEditor as)
         , asContext = ctxList V.empty
@@ -446,11 +449,11 @@ main = do
     Right journal -> do
       let edit = editor EditorName (txt . T.concat) (Just 1) ""
 
-      sugg <- suggest journal date DateQuestion
+      sugg <- suggest journal date (DateQuestion "")
 
       let welcome = "Welcome! Press F1 (or Alt-?) for help. Exit with Ctrl-d."
           matchAlgo = runIdentity $ optMatchAlgo opts
-          as = AppState edit DateQuestion journal (ctxList V.empty) sugg welcome path date matchAlgo NoDialog
+          as = AppState edit (DateQuestion "") journal (ctxList V.empty) sugg welcome path date matchAlgo NoDialog
 
       void $ defaultMain app as
 

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -91,6 +91,8 @@ bindings = KeyBindings
        , ("C-p", "Select the previous context item")
        , ("Tab", "Insert currently selected answer into text area")
        , ("C-z", "Undo")
+       , (";", "Edit comment for current prompt")
+       , ("Alt-;", "Edit transaction comment")
        ])
   , ("Acceptance",
      [ ("Ret", "Accept the currently selected answer")

--- a/tests/ModelSpec.hs
+++ b/tests/ModelSpec.hs
@@ -27,7 +27,7 @@ suggestSpec = do
   context "at the account prompt" $ do
 
     it "suggests nothing for an empty journal" $
-      suggest HL.nulljournal german (AccountQuestion HL.nulltransaction)
+      suggest HL.nulljournal german (AccountQuestion HL.nulltransaction "")
         `shouldReturn` Nothing
 
     it "suggests the accounts in order" $ do
@@ -36,7 +36,7 @@ suggestSpec = do
 
       forM_ (zip (inits postings) postings) $ \(posts, next) -> do
         let t = mkTransaction ((2016, 1, 1), "Foo", map (\(x,y) -> (x, y+1)) posts)
-        suggest j german (AccountQuestion t) `shouldReturn` (Just (fst next))
+        suggest j german (AccountQuestion t "") `shouldReturn` (Just (fst next))
 
 
   context "at the amount prompt" $ do
@@ -47,7 +47,7 @@ suggestSpec = do
 
       forM_ (zip (inits postings) postings) $ \(posts, next) -> do
         let t = mkTransaction ((2016, 1, 1), "Foo", posts)
-        suggest j german (AmountQuestion (fst next) t)
+        suggest j german (AmountQuestion (fst next) t "")
           `shouldReturn` (Just ("€" <> (T.pack $ show $ snd next) <> ".00"))
 
     it "suggests the balancing amount if accounts don't match with similar transaction" $ do
@@ -55,19 +55,19 @@ suggestSpec = do
           j = mkJournal [ ((2017, 1, 1), "Foo", postings) ]
           t = mkTransaction ((2016, 1, 1), "Foo", [("foo", 3)])
 
-      suggest j german (AmountQuestion "y" t) `shouldReturn` (Just "€-3.00")
+      suggest j german (AmountQuestion "y" t "") `shouldReturn` (Just "€-3.00")
 
     it "initially doesn't suggest an amount if there is no similar transaction" $ do
       let j = mkJournal [ ((2017, 1, 1), "Foo", [("x", 2), ("y", 3)]) ]
           t = mkTransaction ((2016, 1, 1), "Bar", [])
 
-      suggest j german (AmountQuestion "y" t) `shouldReturn` Nothing
+      suggest j german (AmountQuestion "y" t "") `shouldReturn` Nothing
 
     it "suggests the balancing amount if there is no similar transaction for the second account" $ do
       let j = mkJournal [ ((2017, 1, 1), "Foo", [("x", 2), ("y", 3)]) ]
           t = mkTransaction ((2016, 1, 1), "Bar", [("foo", 3)])
 
-      suggest j german (AmountQuestion "y" t) `shouldReturn` (Just "€-3.00")
+      suggest j german (AmountQuestion "y" t "") `shouldReturn` (Just "€-3.00")
 
 
 accByFreqSpec :: Spec


### PR DESCRIPTION
Binds <kbd>;</kbd> to edit the comment belonging to the current prompt. <kbd>Alt-;</kbd> is bound to edit the transaction comment independently of the prompt.