### PR TITLE
Restore previous input test on undo

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -268,9 +268,12 @@ doNextStep useSelected as = do
                 -- question instead of to the last account question. So do not
                 -- save the last empty account answer which indicates the end
                 -- of the transaction.
-                , asInputHistory = case s' of
-                    FinalQuestion _ -> asInputHistory as
-                    _               -> inputText : asInputHistory as
+                -- Furthermore, don't save the input if the FinalQuestion is
+                -- answered by 'n' (for no).
+                , asInputHistory = case (asStep as,s') of
+                    (FinalQuestion _, _) -> asInputHistory as
+                    (_, FinalQuestion _) -> asInputHistory as
+                    _                    -> inputText : asInputHistory as
                 }
 
 doUndo :: AppState -> IO AppState

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -263,7 +263,14 @@ doNextStep useSelected as = do
                 , asContext = ctx'
                 , asSuggestion = sugg
                 , asMessage = ""
-                , asInputHistory = inputText : asInputHistory as
+                -- Adhere to the 'undo' behaviour: when in the final
+                -- confirmation question, 'undo' jumps back to the last amount
+                -- question instead of to the last account question. So do not
+                -- save the last empty account answer which indicates the end
+                -- of the transaction.
+                , asInputHistory = case s' of
+                    FinalQuestion _ -> asInputHistory as
+                    _               -> inputText : asInputHistory as
                 }
 
 doUndo :: AppState -> IO AppState


### PR DESCRIPTION
On 'undo' (bound to C-z), restore the previous content of the editor
widget. This simplifies fixing typos and lets you redo the choice
whether want the text to be treat verbatim.