### PR TITLE
Add abbreviated days of the week

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # NEXT RELEASE
 
   - Switch stack builds to ghc 8.4 by default
+  - Add abbreviated days of the week to date completion (e.g. `mon`, `tue`, etc)
 
 # 1.3.6
 


### PR DESCRIPTION
This PR updates `weekDays` to also accept shortened versions of the days of the week.

The logic is slightly complicated, as I needed to sort the list of days by the longest length in order to get `megaparsec` to match the longest day, and rather than doing this my hand I've added some code in so that it _always_ happens.

I also added `yest` as an alternative for `yesterday`.