### PR TITLE
Remove -j2 to use less RAM in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ install:
       (cd "." && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep all
+  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep all
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 


### PR DESCRIPTION
(whoops hit the return button by accident before typing everything in)

This PR removes the `-j2` from `cabal new-build` in the `.travis.yml` file. This should make it use less RAM at the expense of a much longer build time.

See #36 for a failed build due to not enough RAM