### PR TITLE
Can't add transaction with commodity 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# NEXT RELEASE
+
+  - bugfix: Fix check for balanced transactions in the presence of commodities.
+
 # 1.3.10   [2020-01-14]
 
   - dependencies: Support megaparsec-8

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -276,9 +276,7 @@ numPostings = length . HL.tpostings
 
 -- | Returns True if all postings balance and the transaction is not empty
 transactionBalanced :: HL.Transaction -> Bool
-transactionBalanced trans =
-  let (rsum, _, _) = HL.transactionPostingBalances trans
-  in HL.isZeroMixedAmount rsum
+transactionBalanced trans = HL.isTransactionBalanced Nothing trans
 
 -- | Computes the sum of all postings in the transaction and inverts it
 negativeAmountSum :: HL.Transaction -> HL.MixedAmount


### PR DESCRIPTION
*For posterity: The following was originally posted by @edkedk99 and I accidentally converted it into my own comment*

## Error description
When you try to add transaction with only 2 posting and one of them is priced using a commodity, *hledger-iadd* doesn't allow you to save it, but tries to force you to add more 2 postings. Sometimes it says the transaction is not balanced.

## Reproduce error

Add the following transaction using *hledger-iadd*
```
2020/01/22 Apple Stock
Assets:Savings             100 AAPL @ 300
Assets:Checking          -30000
```

## Why it is an error
If you add the above transaction on a journal file, hledger accept it, so *hledger-iadd* should accept too. Also, there is no error when you add this transaction using *hledger add* 