### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/hledger-iadd.cabal
+++ b/hledger-iadd.cabal
@@ -77,7 +77,8 @@ library
                      , xdg-basedir
                      , unordered-containers
                      , free >= 4.12.4
-                     , semigroups >= 0.5.0
+  if impl(ghc < 8.0)
+    build-depends:     semigroups >= 0.5.0
   ghc-options:         -Wall -fdefer-typed-holes -fno-warn-name-shadowing
 
 executable hledger-iadd


### PR DESCRIPTION
It is not needed on newer GHC.