### PR TITLE
Fix compilation on GHC 9.0

### DIFF
--- a/src/Brick/Widgets/HelpMessage.hs
+++ b/src/Brick/Widgets/HelpMessage.hs
@@ -79,7 +79,7 @@ handleHelpEvent _ = return ()
 
 
 resetHelpWidget :: HelpWidget n -> EventM n s ()
-resetHelpWidget = vScrollToBeginning . scroller
+resetHelpWidget x = vScrollToBeginning (scroller x)
 
 key :: Text -> Text -> Widget n
 key k h =  withAttr (helpAttr <> attrName "key") (txt ("  " <> k))


### PR DESCRIPTION
Currently the compilation fails on GHC 9.0:
 
```haskell
src/Brick/Widgets/HelpMessage.hs:82:19: error:
    • Couldn't match type: forall s1. EventM n s1 ()
                     with: EventM n s ()
      Expected: ViewportScroll n -> EventM n s ()
        Actual: ViewportScroll n -> forall s. EventM n s ()
    • In the first argument of ‘(.)’, namely ‘vScrollToBeginning’
      In the expression: vScrollToBeginning . scroller
      In an equation for ‘resetHelpWidget’:
          resetHelpWidget = vScrollToBeginning . scroller
    • Relevant bindings include
        resetHelpWidget :: HelpWidget n -> EventM n s ()
          (bound at src/Brick/Widgets/HelpMessage.hs:82:1)
   |
82 | resetHelpWidget = vScrollToBeginning . scroller
   |                   ^^^^^^^^^^^^^^^^^^
Error: cabal: Failed to build hledger-iadd-1.3.18 (which is required by
exe:hledger-iadd from hledger-iadd-1.3.18).
```

Consider the following functions:

```haskell
vScrollToBeginning :: forall n. ViewportScroll n -> forall s. EventM n s ()
scroller :: forall n. HelpWidget n -> ViewportScroll n
(.) :: forall p q r. (q -> r) -> (p -> q) -> p -> r`
```
In `vScrollToBeginning . scroller`, the return type of the first function, `r`, is instantiated to a polymorphic type `forall s. EventM n s ()`. I think this requires impredicative polymorphism. To fix that, we could either enable `ImpredicativeTypes` or eta expand the function to remove `.`. Given that `ImpredicativeTypes` is flaky before GHC 9.2, I just use eta expansion. BTW the original code compiles on GHC 9.2 even without `ImpredicativeTypes` enabled. Please correct me If I missed anything. 