### PR TITLE
Bump brick and vty versions

### DIFF
--- a/hledger-iadd.cabal
+++ b/hledger-iadd.cabal
@@ -42,7 +42,7 @@ extra-source-files:
 source-repository head
   type: git
   location: https://github.com/hpdeifel/hledger-iadd.git
-  
+
 library
   hs-source-dirs:      src
   exposed-modules:     Model
@@ -61,8 +61,8 @@ library
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 5
                      , hledger-lib >= 1.29 && < 1.33
-                     , brick >= 1.5
-                     , vty >= 5.4
+                     , brick >= 2.1 && < 2.4
+                     , vty >= 6.1 && < 6.2
                      , text
                      , microlens
                      , microlens-th
@@ -88,8 +88,8 @@ executable hledger-iadd
   build-depends:       base >= 4.12 && < 5
                      , hledger-iadd
                      , hledger-lib >= 1.29 && <1.33
-                     , brick >= 1.5
-                     , vty >= 5.4
+                     , brick >= 2.1 && < 2.4
+                     , vty >= 6.1 && < 6.2
                      , text
                      , microlens
                      , microlens-th

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,10 @@
 packages:
   - .
 extra-deps:
- - hledger-lib-1.15.2
-resolver: lts-14.14
+ - brick-2.1.1
+ - vty-6.1
+ - vty-crossplatform-0.4.0.0
+ - vty-unix-0.2.0.0
+ - vty-windows-0.2.0.1
+ - hledger-lib-1.32.2
+resolver: lts-21.25


### PR DESCRIPTION
This allows building `hledger-iadd` on windows.

The supported terminal emulators do not cover the full spectrum, but that's a start. This article has https://github.com/chhackett/vty-windows/wiki/TerminalSupport some more info.